### PR TITLE
Add Spring Security support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ ng build
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
 
+### Running with Spring Boot
+
+After building the Angular project, the output is copied to `api/target/classes/static/`.  Start the backend server to serve these files (secured by Spring Security) with:
+
+```bash
+mvn -pl api spring-boot:run
+```
+
+Once running, access `http://localhost:8081/` to view the Angular application served by Spring Boot.
+
 ## Running unit tests
 
 To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,10 +20,10 @@
 <!--      <groupId>org.springframework.boot</groupId>-->
 <!--      <artifactId>spring-boot-starter-data-jpa</artifactId>-->
 <!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.springframework.boot</groupId>-->
-<!--      <artifactId>spring-boot-starter-security</artifactId>-->
-<!--    </dependency>-->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>

--- a/api/src/main/java/br/com/pelusci/fullstack/config/SecurityConfig.java
+++ b/api/src/main/java/br/com/pelusci/fullstack/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package br.com.pelusci.fullstack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/**").authenticated()
+                .anyRequest().permitAll())
+            .formLogin()
+            .and()
+            .httpBasic();
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary
- enable Spring Security in the API
- create basic security config
- document how to run the Angular build through Spring Boot

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680b60b3e48322b3ac641e1454ef5c